### PR TITLE
Set the default value name for xml elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The variable fields are injected via the `$(foo)` notation, where 'foo' is a jso
 ```
 
 XML elements might have additional attributes and can be reached by using property name `$(foo.type)` and `$(foo.value)`.
-Keep in mind that the root element (in this case <root></root>) doesn't present in the resulting map.
+Keep in mind that the root element (in this case `<root></root>`) doesn't present in the resulting map.
 ```
 <root><foo type="string">bar</foo></root>
 ```

--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ The variable fields are injected via the `$(foo)` notation, where 'foo' is a jso
     "foo": "bar"
 }
 ```
+
+XML elements might have additional attributes and can be reached by using property name `$(foo.type)` and `$(foo.value)`.
+Keep in mind that the root element (in this case <root></root>) doesn't present in the resulting map.
 ```
-<foo>bar</foo>
+<root><foo type="string">bar</foo></root>
 ```
 
 ###Nested Fields
@@ -35,10 +38,12 @@ For example:
 	}
 }
 ```
+The value `opentable` is referenced via `$(foo.bar)` in your response body.
+
 ```
-<foo><bar>opentable</bar></foo>
+<root><foo><bar type="string">opentable</bar></foo></root>
 ```
-The attribute `opentable` is referenced via `$(foo.bar)` in your response body.
+The value `opentable` is referenced via `$(foo.bar.value)` and type 'string' via `$(foo.bar.type)` in your response body.
 
 
 ###Usage
@@ -94,7 +99,7 @@ Add the transformer into the specific stub via the "body-transformer" name.
     "response": {
         "status": 200,
         "body": "{\"name\": \"$(var)\"}",
-        "responseTransformers": ["body-transformer"]
+        "transformers": ["body-transformer"]
     }
 }
 ```
@@ -118,7 +123,7 @@ For the following stub:
 		"headers": {
 			"Content-Type": "application/json"
 		},
-		"responseTransformers": ["body-transformer"]
+		"transformers": ["body-transformer"]
 	}
 }
 ```
@@ -154,7 +159,7 @@ With the pattern `$(!RandomInteger)` inside the stub response body, a random pos
 		"headers": {
 			"Content-Type": "application/json"
 		},
-		"responseTransformers": ["body-transformer"]
+		"transformers": ["body-transformer"]
 	}
 }
 ```

--- a/src/main/java/com/opentable/extension/BodyTransformer.java
+++ b/src/main/java/com/opentable/extension/BodyTransformer.java
@@ -15,6 +15,7 @@
 package com.opentable.extension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.common.BinaryFile;
@@ -35,7 +36,7 @@ public class BodyTransformer extends ResponseTransformer {
     private final Pattern interpolationPattern = Pattern.compile("\\$\\(.*?\\)");
     private final Pattern randomIntegerPattern = Pattern.compile("!RandomInteger");
     private ObjectMapper jsonMapper = new ObjectMapper();
-    private ObjectMapper xmlMapper = new XmlMapper();
+    private ObjectMapper xmlMapper;
 
     @Override
     public ResponseDefinition transform(Request request, ResponseDefinition responseDefinition, FileSource files) {
@@ -45,6 +46,10 @@ public class BodyTransformer extends ResponseTransformer {
         } catch (IOException e) {
             try
             {
+				JacksonXmlModule configuration = new JacksonXmlModule();
+				//Set the default value name for xml elements like <user type="String">Dmytro</user>
+				configuration.setXMLTextElementName("value");
+				xmlMapper = new XmlMapper(configuration);
                 object = xmlMapper.readValue(request.getBodyAsString(), Map.class);
             }
             catch (IOException ex)


### PR DESCRIPTION
For XMLs like:
```xml
<request>
  <user>
    <name type="String">Dmytro</name>
    <age type="Number">29</age>
  </user>
</request>
```
If you are requesting **${user.name}**, you will get the map **{"type" = "String", ""="Dmytro"}** with the empty key for the value and therefore, you can't get it in the JSON configuration. 

My changes set up the default name "value" and you can reach it using **${user.name.value}**