### PR TITLE
Added parsing logic for the key=value body requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Form fields value can be UTF-8 encoded, empty or not empty.
 ````
 utf8=%E2%9C%93&foo=bar&emptyFoo=&encodedFoo=Encoded+Foo+Value
 ````
-`$(foo)` will return `bar`
-`$(emptyFoo)` will return empty string
-`$(encodedFoo)` will return `Encoded Foo Value`
+`$(foo)` will return `bar`,
+`$(emptyFoo)` will return empty string,
+`$(encodedFoo)` will return `Encoded Foo Value`.
 
 ###Nested Fields
 You can specify nested fields via dot notations.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Built on the extensions platform of Wiremock, it allows your wiremock response t
 ```
 
 ###How It Works
-The body transformer supports both __JSON__ and __XML__ formats.
+The body transformer supports __JSON__, __XML__ and __x-www-form-urlencoded__ formats.
 
-The response body stub acts as a template where the variables come from the request json/xml body similar to string interpolation.
+The response body stub acts as a template where the variables come from the request json/xml/form body similar to string interpolation.
 The variable fields are injected via the `$(foo)` notation, where 'foo' is a json field in the request body.
 ```
 {
@@ -27,6 +27,14 @@ Keep in mind that the root element (in this case `<root></root>`) doesn't presen
 ```
 <root><foo type="string">bar</foo></root>
 ```
+
+Form fields value can be UTF-8 encoded, empty or not empty. 
+````
+utf8=%E2%9C%93&foo=bar&emptyFoo=&encodedFoo=Encoded+Foo+Value
+````
+`$(foo)` will return `bar`
+`$(emptyFoo)` will return empty string
+`$(encodedFoo)` will return `Encoded Foo Value`
 
 ###Nested Fields
 You can specify nested fields via dot notations.

--- a/src/main/java/com/opentable/extension/BodyTransformer.java
+++ b/src/main/java/com/opentable/extension/BodyTransformer.java
@@ -100,8 +100,10 @@ public class BodyTransformer extends ResponseDefinitionTransformer {
 	@Override
 	public ResponseDefinition transform(Request request, ResponseDefinition responseDefinition, FileSource fileSource, Parameters parameters) {
 		Map object = null;
+		String requestBody = request.getBodyAsString();
+
 		try {
-			object = jsonMapper.readValue(request.getBodyAsString(), Map.class);
+			object = jsonMapper.readValue(requestBody, Map.class);
 		} catch (IOException e) {
 			try
 			{
@@ -109,16 +111,15 @@ public class BodyTransformer extends ResponseDefinitionTransformer {
 				//Set the default value name for xml elements like <user type="String">Dmytro</user>
 				configuration.setXMLTextElementName("value");
 				xmlMapper = new XmlMapper(configuration);
-				object = xmlMapper.readValue(request.getBodyAsString(), Map.class);
+				object = xmlMapper.readValue(requestBody, Map.class);
 			}
 			catch (IOException ex)
 			{
 				//Validate is a body has the 'name=value' parameters
-				String body = request.getBodyAsString();
-				if(StringUtils.isNotEmpty(body) && (body.contains("&") || body.contains("=")))
+				if(StringUtils.isNotEmpty(requestBody) && (requestBody.contains("&") || requestBody.contains("=")))
 				{
 					object = new HashMap();
-					String [] pairedValues = request.getBodyAsString().split("&");
+					String [] pairedValues = requestBody.split("&");
 					for(String pair: pairedValues)
 					{
 						String[] values = pair.split("=");

--- a/src/main/java/com/opentable/extension/BodyTransformer.java
+++ b/src/main/java/com/opentable/extension/BodyTransformer.java
@@ -23,9 +23,11 @@ import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import org.apache.commons.lang.StringUtils;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.regex.Matcher;
@@ -54,7 +56,20 @@ public class BodyTransformer extends ResponseTransformer {
             }
             catch (IOException ex)
             {
-                ex.printStackTrace();
+                //Validate is a body has the 'name=value' parameters
+                String body = request.getBodyAsString();
+                if(StringUtils.isNotEmpty(body) && (body.contains("&") || body.contains("=")))
+                {
+                    object = new HashMap();
+                    String [] pairedValues = request.getBodyAsString().split("&");
+                    for(String pair: pairedValues)
+                    {
+                        String[] values = pair.split("=");
+                        object.put(values[0], values[1]);
+                    }
+                } else {
+                    System.err.println("[Body parse error] The body doesn't match any of 3 possible formats (JSON, XML, key=value).");
+                }
             }
         }
 

--- a/src/main/java/com/opentable/extension/BodyTransformer.java
+++ b/src/main/java/com/opentable/extension/BodyTransformer.java
@@ -65,7 +65,7 @@ public class BodyTransformer extends ResponseTransformer {
                     for(String pair: pairedValues)
                     {
                         String[] values = pair.split("=");
-                        object.put(values[0], values[1]);
+                        object.put(values[0], values.length > 1 ? values[1] : "");
                     }
                 } else {
                     System.err.println("[Body parse error] The body doesn't match any of 3 possible formats (JSON, XML, key=value).");

--- a/src/main/java/com/opentable/extension/BodyTransformer.java
+++ b/src/main/java/com/opentable/extension/BodyTransformer.java
@@ -24,7 +24,7 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -40,56 +40,6 @@ public class BodyTransformer extends ResponseDefinitionTransformer {
     private final Pattern randomIntegerPattern = Pattern.compile("!RandomInteger");
     private ObjectMapper jsonMapper = new ObjectMapper();
     private ObjectMapper xmlMapper;
-
-    @Override
-    public ResponseDefinition transform(Request request, ResponseDefinition responseDefinition, FileSource files) {
-        Map object = null;
-        try {
-            object = jsonMapper.readValue(request.getBodyAsString(), Map.class);
-        } catch (IOException e) {
-            try
-            {
-				JacksonXmlModule configuration = new JacksonXmlModule();
-				//Set the default value name for xml elements like <user type="String">Dmytro</user>
-				configuration.setXMLTextElementName("value");
-				xmlMapper = new XmlMapper(configuration);
-                object = xmlMapper.readValue(request.getBodyAsString(), Map.class);
-            }
-            catch (IOException ex)
-            {
-                //Validate is a body has the 'name=value' parameters
-                String body = request.getBodyAsString();
-                if(StringUtils.isNotEmpty(body) && (body.contains("&") || body.contains("=")))
-                {
-                    object = new HashMap();
-                    String [] pairedValues = request.getBodyAsString().split("&");
-                    for(String pair: pairedValues)
-                    {
-                        String[] values = pair.split("=");
-                        object.put(values[0], values.length > 1 ? values[1] : "");
-                    }
-                } else {
-                    System.err.println("[Body parse error] The body doesn't match any of 3 possible formats (JSON, XML, key=value).");
-                }
-            }
-        }
-
-        if (hasEmptyBody(responseDefinition)) {
-            return responseDefinition;
-        }
-
-        String body = getBody(responseDefinition, files);
-
-        return ResponseDefinitionBuilder
-                .like(responseDefinition).but()
-                .withBodyFile(null)
-                .withBody(transformResponse(object, body))
-                .build();
-    }
-
-    public String name() {
-        return "body-transformer";
-    }
 
     @Override
     public boolean applyGlobally() {
@@ -144,5 +94,56 @@ public class BodyTransformer extends ResponseDefinitionTransformer {
         }
         return body;
     }
+
+	@Override
+	public ResponseDefinition transform(Request request, ResponseDefinition responseDefinition, FileSource fileSource, Parameters parameters) {
+		Map object = null;
+		try {
+			object = jsonMapper.readValue(request.getBodyAsString(), Map.class);
+		} catch (IOException e) {
+			try
+			{
+				JacksonXmlModule configuration = new JacksonXmlModule();
+				//Set the default value name for xml elements like <user type="String">Dmytro</user>
+				configuration.setXMLTextElementName("value");
+				xmlMapper = new XmlMapper(configuration);
+				object = xmlMapper.readValue(request.getBodyAsString(), Map.class);
+			}
+			catch (IOException ex)
+			{
+				//Validate is a body has the 'name=value' parameters
+				String body = request.getBodyAsString();
+				if(StringUtils.isNotEmpty(body) && (body.contains("&") || body.contains("=")))
+				{
+					object = new HashMap();
+					String [] pairedValues = request.getBodyAsString().split("&");
+					for(String pair: pairedValues)
+					{
+						String[] values = pair.split("=");
+						object.put(values[0], values.length > 1 ? values[1] : "");
+					}
+				} else {
+					System.err.println("[Body parse error] The body doesn't match any of 3 possible formats (JSON, XML, key=value).");
+				}
+			}
+		}
+
+		if (hasEmptyBody(responseDefinition)) {
+			return responseDefinition;
+		}
+
+		String body = getBody(responseDefinition, fileSource);
+
+		return ResponseDefinitionBuilder
+			.like(responseDefinition).but()
+			.withBodyFile(null)
+			.withBody(transformResponse(object, body))
+			.build();
+	}
+
+	@Override
+	public String getName() {
+		return "body-transformer";
+	}
 }
 

--- a/src/main/java/com/opentable/extension/BodyTransformer.java
+++ b/src/main/java/com/opentable/extension/BodyTransformer.java
@@ -27,6 +27,8 @@ import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -120,7 +122,7 @@ public class BodyTransformer extends ResponseDefinitionTransformer {
 					for(String pair: pairedValues)
 					{
 						String[] values = pair.split("=");
-						object.put(values[0], values.length > 1 ? values[1] : "");
+						object.put(values[0], values.length > 1 ? decodeUTF8Value(values[1]) : "");
 					}
 				} else {
 					System.err.println("[Body parse error] The body doesn't match any of 3 possible formats (JSON, XML, key=value).");
@@ -141,6 +143,17 @@ public class BodyTransformer extends ResponseDefinitionTransformer {
 			.build();
 	}
 
+	private String decodeUTF8Value(String value) {
+
+		String decodedValue = "";
+		try {
+			decodedValue = URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+		} catch (UnsupportedEncodingException e) {
+			System.err.println("[Body parse error] Can't decode one of the request parameter. It should be UTF-8 charset.");
+		}
+
+		return decodedValue;
+	}
 	@Override
 	public String getName() {
 		return "body-transformer";

--- a/src/test/java/com/opentable/extension/BodyTransformerTest.java
+++ b/src/test/java/com/opentable/extension/BodyTransformerTest.java
@@ -74,7 +74,14 @@ public class BodyTransformerTest {
     public void replaceVariableHolderFromKeyValueRequest() throws Exception {
         final String requestBody = "utf8=%E2%9C%93&auth_cv_result=M&req_locale=en-us&decision_case_priority=3";
         testKeyValueBodyRequest(requestBody);
+
     }
+
+	@Test
+	public void replaceVariableHolderFromKeyRequest() throws Exception {
+		final String requestBody = "EmptyKey=";
+		testKeyBodyRequest(requestBody);
+	}
 
     private void testKeyValueBodyRequest(String body) {
         wireMockRule.stubFor(post(urlEqualTo("/get/this"))
@@ -95,6 +102,25 @@ public class BodyTransformerTest {
         wireMockRule.verify(postRequestedFor(urlEqualTo("/get/this")));
 
     }
+	private void testKeyBodyRequest(String body) {
+		wireMockRule.stubFor(post(urlEqualTo("/get/this"))
+			.willReturn(aResponse()
+				.withStatus(200)
+				.withHeader("content-type", "application/json")
+				.withBody("{\"EmptyKey\":\"\"}")
+				.withTransformers("body-transformer")));
+		given()
+			.contentType("application/x-www-form-urlencoded")
+			.body(body)
+		.when()
+			.post("/get/this")
+		.then()
+			.statusCode(200)
+			.body("EmptyKey", equalTo(""));
+
+		wireMockRule.verify(postRequestedFor(urlEqualTo("/get/this")));
+
+	}
 
 	private void testNestedField(String requestBody)
 	{

--- a/src/test/java/com/opentable/extension/BodyTransformerTest.java
+++ b/src/test/java/com/opentable/extension/BodyTransformerTest.java
@@ -77,12 +77,11 @@ public class BodyTransformerTest {
     public void replaceVariableHolderFromKeyValueRequest() throws Exception {
         final String requestBody = "utf8=%E2%9C%93&auth_cv_result=M&req_locale=en-us&decision_case_priority=3";
         testKeyValueBodyRequest(requestBody);
-
     }
 
 	@Test
 	public void replaceVariableHolderFromKeyRequest() throws Exception {
-		final String requestBody = "EmptyKey=";
+		final String requestBody = "EmptyKey=&NotEmptyKey=Not+Empty+Val";
 		testKeyBodyRequest(requestBody);
 	}
 
@@ -103,14 +102,14 @@ public class BodyTransformerTest {
             .body("auth_cv_result", equalTo("M"));
 
         wireMockRule.verify(postRequestedFor(urlEqualTo("/get/this")));
-
     }
+
 	private void testKeyBodyRequest(String body) {
 		wireMockRule.stubFor(post(urlEqualTo("/get/this"))
 			.willReturn(aResponse()
 				.withStatus(200)
 				.withHeader("content-type", "application/json")
-				.withBody("{\"EmptyKey\":\"\"}")
+				.withBody("{\"EmptyKey\":\"$(EmptyKey)\", \"NotEmptyKey\" : \"$(NotEmptyKey)\"}")
 				.withTransformers("body-transformer")));
 		given()
 			.contentType("application/x-www-form-urlencoded")
@@ -119,10 +118,10 @@ public class BodyTransformerTest {
 			.post("/get/this")
 		.then()
 			.statusCode(200)
-			.body("EmptyKey", equalTo(""));
+			.body("EmptyKey", equalTo(""))
+			.body("NotEmptyKey", equalTo("Not Empty Val"));
 
 		wireMockRule.verify(postRequestedFor(urlEqualTo("/get/this")));
-
 	}
 
 	private void testNestedField(String requestBody)

--- a/src/test/java/com/opentable/extension/BodyTransformerTest.java
+++ b/src/test/java/com/opentable/extension/BodyTransformerTest.java
@@ -70,6 +70,32 @@ public class BodyTransformerTest {
 		testNestedField(requestBody);
 	}
 
+    @Test
+    public void replaceVariableHolderFromKeyValueRequest() throws Exception {
+        final String requestBody = "utf8=%E2%9C%93&auth_cv_result=M&req_locale=en-us&decision_case_priority=3";
+        testKeyValueBodyRequest(requestBody);
+    }
+
+    private void testKeyValueBodyRequest(String body) {
+        wireMockRule.stubFor(post(urlEqualTo("/get/this"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("content-type", "application/json")
+                .withBody("{\"auth_cv_result\":\"$(auth_cv_result)\"}")
+                .withTransformers("body-transformer")));
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .body(body)
+        .when()
+            .post("/get/this")
+        .then()
+            .statusCode(200)
+            .body("auth_cv_result", equalTo("M"));
+
+        wireMockRule.verify(postRequestedFor(urlEqualTo("/get/this")));
+
+    }
+
 	private void testNestedField(String requestBody)
 	{
 		wireMockRule.stubFor(post(urlEqualTo("/get/this"))


### PR DESCRIPTION
Added parsing logic for the requests of type **application/x-www-form-urlencoded** with the key=value body string. 

I didn't find another way to reach them except to extend an existing logic. 
If you think it will be useful I can update documentation for this feature. 
If you know another way how to do it I'll be also glad to hear it. 
