### PR TITLE
Added support for URL pattern matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,32 @@ The value `opentable` is referenced via `$(foo.bar)` in your response body.
 ```
 The value `opentable` is referenced via `$(foo.bar.value)` and type 'string' via `$(foo.bar.type)` in your response body.
 
+### URL Pattern Matching
+You can use this feature to extract query parameters or parts of the URL. Pass in additional transformer parameters to do url pattern matching. 
+Pass a regex parameter named `urlRegex` to match the url and extract relevant groups. Pass in the comma-delimited group names as a `groupNames` parameter.
+
+##### Example
+Fetching a url like: /params/slash1/10/slash2/20?one=value1&two=value2&three=value3 using the following code in Java:
+```
+    wireMockRule.stubFor(get(urlMatching("/params/slash1/[0-9]+?/slash2/[0-9]+?.*"))
+        .willReturn(aResponse()
+            .withStatus(200)
+            .withHeader("content-type", "application/json")
+            .withBody("{\"slash1\":\"$(slash1Var)\", \"slash2\":\"$(slash2Var)\", \"one\":\"$(oneVar)\", \"two\":\"$(twoVar)\", \"three\":\"$(threeVar)\"}")
+            .withTransformers("body-transformer")
+        .withTransformerParameter("urlRegex", "/params/slash1/(.*?)/slash2/(.*?)\\?one=(.*?)\\&two=(.*?)\\&three=(.*?)")
+        .withTransformerParameter("groupNames", "slash1Var,slash2Var,oneVar,twoVar,threeVar")));
+```
+returns a body that looks like:
+```
+{
+    "slash1": "10",
+    "slash2": "20",
+    "one": "value1",
+    "two": "value2",
+    "three": "value3"
+}
+```
 
 ###Usage
 
@@ -169,3 +195,4 @@ The sample response body will return:
     "randomInteger": 56542
 }
 ```
+


### PR DESCRIPTION
Added regex based pattern matching for incoming request URLs that allows extracted regex groups to be included in variable replacements. This allows values to be extracted from query parameters, etc in the URL and be included in the response body.
