### PR TITLE
The check for response definition has empty body and empty bodyFIle

### DIFF
--- a/src/main/java/com/opentable/extension/BodyTransformer.java
+++ b/src/main/java/com/opentable/extension/BodyTransformer.java
@@ -100,7 +100,11 @@ public class BodyTransformer extends ResponseDefinitionTransformer {
 
     @Override
     public ResponseDefinition transform(Request request, ResponseDefinition responseDefinition, FileSource fileSource, Parameters parameters) {
-        Map object = null;
+		if (hasEmptyBody(responseDefinition)) {
+			return responseDefinition;
+		}
+
+    	Map object = null;
         String requestBody = request.getBodyAsString();
 
         try {
@@ -160,10 +164,6 @@ public class BodyTransformer extends ResponseDefinitionTransformer {
                     }
                 }
             }
-        }
-
-        if (hasEmptyBody(responseDefinition)) {
-            return responseDefinition;
         }
 
         String body = getBody(responseDefinition, fileSource);

--- a/src/test/java/com/opentable/extension/BodyTransformerTest.java
+++ b/src/test/java/com/opentable/extension/BodyTransformerTest.java
@@ -18,7 +18,14 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.jayway.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;

--- a/src/test/java/com/opentable/extension/BodyTransformerTest.java
+++ b/src/test/java/com/opentable/extension/BodyTransformerTest.java
@@ -18,13 +18,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.jayway.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
@@ -329,6 +323,23 @@ public class BodyTransformerTest {
 			.then()
 			.statusCode(500);
 
+	}
+
+	@Test
+	public void testEmptyBodyAndEmptyBodyFile() {
+    	wireMockRule.stubFor(any(urlMatching("/any/emptyBodyAndEmptyBodyFile"))
+			.willReturn(aResponse()
+				.withStatus(200)
+				.withTransformers("body-transformer")));
+
+    	given()
+			.when()
+			.get("/any/emptyBodyAndEmptyBodyFile")
+			.then()
+			.statusCode(200)
+			.body(equalTo(""));
+
+		wireMockRule.verify(getRequestedFor(urlMatching("/any/emptyBodyAndEmptyBodyFile")));
 	}
 
 }


### PR DESCRIPTION
1. Added simple test for situation when response definition has empty body and empty bodyFIle.
The check is moved to the beginning of the method.

2. Make code more readable.